### PR TITLE
Fix missing output when VOD categories are disabled and only genres are enabled

### DIFF
--- a/MacAttack.pyw
+++ b/MacAttack.pyw
@@ -4202,8 +4202,10 @@ class MacAttack(QMainWindow):
                                         # Replace the grid with the list for the file
                                         if include_genres and titles_str and titles_grid:
                                             result_message = result_message.replace(titles_grid, orig_genres)
-                                            result_message = result_message.replace(vods_grid, orig_vods)
                                             logging.debug("Replacing playlist grid with list for file")
+                                        if include_vod and vod_str and vods_grid:
+                                            result_message = result_message.replace(vods_grid, orig_vods)
+                                            logging.debug("Replacing vod grid with list for file")
                                         self.output_file.write(result_message + "\n")
                                         self.output_file.flush()
 


### PR DESCRIPTION
This fixes a bug where the result message was not written to the output file if VOD categories were disabled in the settings and only genres were enabled. The issue occurred because the vods_grid variable was accessed without being initialized, causing the output logic to fail silently.

**Steps to Reproduce:**

1. Disable VOD Categories in the output settings.
2. Enable Playlist/Genres in the output settings.
3. Run it and observe that the result message is not written to the output file.